### PR TITLE
Reorganize start page into 4 balanced columns

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,34 +43,37 @@
             <a href="http://localhost:8384/">Syncthing (local)</a>
         </div>
         <div class="list_card">
-            <h2 class="list_title" id="m">Media</h2>
+            <h2 class="list_title" id="r">Reading</h2>
             <a href="https://lobste.rs/">lobsters</a>
             <a href="https://news.ycombinator.com/">Hacker News</a>
-            <a href="https://www.daringfireball.net/">DF</a>
+            <a href="https://www.daringfireball.net/">Daring Fireball</a>
             <a href="https://simonwillison.net/">Simon Willison</a>
             <a href="https://blog.fsck.com/">fsck - Jesse Vincent</a>
-            <a href="https://xkcd.com/">xkcd</a>
-            <a href="https://www.theverge.com">The Verge</a>
-            <a href="https://www.macrumors.com">MacRumors</a>
             <a href="https://www.leancrew.com/all-this/">Dr. Drang</a>
-            <a href="https://9to5mac.com">9to5Mac</a>
-            <a href="https://www.reddit.com/">Reddit</a>
-            <a href="https://www.youtube.com">YouTube</a>
-            <a href="https://slickdeals.net/deals/musical-instruments/">SD insruments</a>
+            <a href="https://xkcd.com/">xkcd</a>
         </div>
         <div class="list_card">
             <h2 class="list_title" id="d">Dev</h2>
             <a href="https://chatgpt.com/codex">ChatGPT Codex</a>
             <a href="https://github.com/">Github</a>
             <a href="https://sourcehut.org/">Sourcehut(fka sr.ht)</a>
-        </div>
-        <div class="list_card">
-            <h2 class="list_title" id="l">*Nix</h2>
             <a href="https://wiki.archlinux.org/">Arch Wiki</a>
             <a href="https://alltop.com/linux">Alltop/linux</a>
             <a href="https://reddit.com/r/unixporn">/r/unixporn</a>
             <a href="https://xn--gckvb8fzb.com">ごくふつうのブログ</a>
             <a href="http://start.laydros.net/openbsd_install.html">OpenBSD install</a>
+        </div>
+        <div class="list_card">
+            <h2 class="list_title" id="n">News</h2>
+            <a href="https://spike.news/">spike.news</a>
+            <a href="https://www.theregister.com/">The Register</a>
+            <a href="https://arstechnica.com/">Ars Technica</a>
+            <a href="https://www.theverge.com">The Verge</a>
+            <a href="https://www.macrumors.com">MacRumors</a>
+            <a href="https://9to5mac.com">9to5Mac</a>
+            <a href="https://www.reddit.com/">Reddit</a>
+            <a href="https://www.youtube.com">YouTube</a>
+            <a href="https://slickdeals.net/deals/musical-instruments/">SD instruments</a>
         </div>
 
     </div>


### PR DESCRIPTION
- Renamed columns: Tools, Reading, Dev, News (previously Tools, Media, Dev, *Nix)
- Moved tech blogs and aggregators to new "Reading" column
- Merged Dev and *Nix content into unified "Dev" column
- Created "News" column for tech news sites and community
- Added 3 new sites: spike.news, The Register, Ars Technica
- Fixed typo: "SD insruments" → "SD instruments"

This creates a more balanced distribution (7-7-8-9) vs previous (7-13-3-5)